### PR TITLE
Add CLI support and file validation with logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+use chrono::Utc;
+use std::fs;
+
+pub fn validate_rust_file(file_path: &str) -> Result<(), String> {
+    println!("[{}] Validating file: {}", Utc::now(), file_path);
+
+    let content = fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read file: {}", e))?;
+
+    if !content.contains("fn main") {
+        return Err("Missing `fn main` entry point.".into());
+    }
+
+    if content.contains("let _") {
+        return Err("Contains unused variable pattern `let _`.".into());
+    }
+
+    Ok(())
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,20 @@
-use std::process::Command;
 use std::env;
+use std::process::Command;
 use std::str;
+use rust_checker::validate_rust_file;
+use chrono::Utc;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: cargo run <path_to_rust_project>");
+        eprintln!("Usage: cargo run -- <path_to_rust_project>");
         std::process::exit(1);
     }
+
     let project_path = &args[1];
+    println!("[{}] Checking Rust project at: {}", Utc::now(), project_path);
 
-    println!("Checking Rust project for compilation errors at: {}", project_path);
-
+    // Step 1: Run cargo check
     let output = Command::new("cargo")
         .arg("check")
         .current_dir(project_path)
@@ -19,11 +22,18 @@ fn main() {
         .expect("Failed to execute cargo check");
 
     if output.status.success() {
-        println!(" No compilation errors found!");
+        println!(" No compilation errors found.");
     } else {
         println!(" Compilation errors detected:");
         let stderr = str::from_utf8(&output.stderr).unwrap_or("Unknown error");
         parse_and_display_errors(stderr);
+    }
+
+    // Step 2: Run custom validation on main.rs
+    let file_path = format!("{}/src/main.rs", project_path);
+    match validate_rust_file(&file_path) {
+        Ok(_) => println!(" Code style validation passed."),
+        Err(e) => eprintln!(" Validation failed: {}", e),
     }
 }
 

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,0 +1,28 @@
+use rust_checker::validate_rust_file;
+use std::fs::File;
+use std::io::Write;
+
+#[test]
+fn test_validate_valid_file() {
+    let path = "tests/temp_valid.rs";
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "fn main() {{ println!(\"Hello\"); }}").unwrap();
+
+    let result = validate_rust_file(&path);
+    assert!(result.is_ok());
+
+    std::fs::remove_file(&path).unwrap(); // Clean up after test
+}
+
+#[test]
+fn test_validate_missing_main() {
+    let path = "tests/temp_invalid.rs";
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "fn helper() {{}}").unwrap();
+
+    let result = validate_rust_file(&path);
+    assert!(result.is_err());
+
+    std::fs::remove_file(&path).unwrap(); // Clean up after test
+}
+


### PR DESCRIPTION
This pull request introduces the following enhancements:

- Adds CLI entry point via `main.rs` to validate Rust project paths
- Integrates `cargo check` execution with custom error parsing
- Implements file-level validation logic in `lib.rs`
  - Checks for missing `fn main`
  - Detects unused variable patterns
- Adds timestamped logs via `chrono`
- Includes integration tests in `tests/validate.rs`

Co-authored-by: hansonp <hansonp303@gmail.com>
