### PR TITLE
Add validation summary report to CLI output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,21 @@ use std::process::Command;
 use std::str;
 use rust_checker::{validate_rust_file, scanner::scan_rust_files};
 use chrono::Utc;
+use colored::*;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("Usage: cargo run -- <path_to_rust_project>");
+        eprintln!("{}", "Usage: cargo run -- <path_to_rust_project>".red());
         std::process::exit(1);
     }
 
     let project_path = &args[1];
-    println!("[{}] Checking Rust project recursively at: {}\n", Utc::now(), project_path);
+    println!(
+        "{}",
+        format!("[{}] Checking Rust project recursively at: {}\n", Utc::now(), project_path).blue()
+    );
 
     // Step 1: Run cargo check
     let output = Command::new("cargo")
@@ -23,33 +27,53 @@ fn main() {
         .expect("Failed to execute cargo check");
 
     if output.status.success() {
-        println!(" No compilation errors found.\n");
+        println!("{}", " No compilation errors found.\n".green());
     } else {
-        println!(" Compilation errors detected:");
+        println!("{}", " Compilation errors detected:".red());
         let stderr = str::from_utf8(&output.stderr).unwrap_or("Unknown error");
         parse_and_display_errors(stderr);
     }
 
-    // Step 2: Recursively validate each Rust file
+    // Step 2: Recursively validate each Rust file and track summary
     let rust_files = scan_rust_files(project_path);
     if rust_files.is_empty() {
-        println!("️ No .rs files found in the directory.");
+        println!("{}", " No .rs files found in the directory.".yellow());
+        return;
     }
+
+    let mut passed = 0;
+    let mut failed = 0;
 
     for file_path in rust_files {
         match validate_rust_file(&file_path) {
-            Ok(_) => println!(" {} passed validation.", file_path),
-            Err(e) => eprintln!(" {} failed validation: {}", file_path, e),
+            Ok(_) => {
+                println!("{}", format!(" {} passed validation.", file_path).green());
+                passed += 1;
+            }
+            Err(e) => {
+                eprintln!("{}", format!(" {} failed validation: {}", file_path, e).red());
+                failed += 1;
+            }
         }
     }
+
+    let total = passed + failed;
+    println!(
+        "\n{}",
+        format!(
+            " Summary:  {} passed |  {} failed | 📄 {} total files checked",
+            passed, failed, total
+        )
+        .bold()
+    );
 }
 
 fn parse_and_display_errors(output: &str) {
     for line in output.lines() {
         if line.contains("error:") {
-            println!("\n {}", line);
+            println!("{}", format!("\n{}", line).red());
         } else if line.contains("--> ") {
-            println!(" {}", line);
+            println!("{}", line.yellow());
         } else {
             println!("  {}", line);
         }


### PR DESCRIPTION
This PR enhances the CLI by summarizing the validation results for each Rust file:

- Tracks number of files passed and failed
- Prints a summary at the end of execution
- Uses colored output for clarity

Example output:
 Summary:  12 passed |  3 failed |  15 total files checked

Co-authored-by: hansonp <hansonp303@gmail.com>
