### PR TITLE
Add JSON report output with --json flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4"
-
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,27 +2,30 @@ use chrono::Utc;
 use std::fs;
 
 pub mod unused_checker;
-use unused_checker::check_unused_imports;
+pub mod rules;
 
-pub fn validate_rust_file(file_path: &str) -> Result<(), String> {
+use unused_checker::check_unused_imports;
+use rules::RuleConfig;
+
+/// Validate a file based on rules provided in RuleConfig
+pub fn validate_rust_file(file_path: &str, config: &RuleConfig) -> Result<(), String> {
     println!("[{}] Validating file: {}", Utc::now(), file_path);
 
     let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read file: {}", e))?;
 
-    // Rule 1: Check for missing main
-    if !content.contains("fn main") {
+    if config.check_main && !content.contains("fn main") {
         return Err("Missing `fn main` entry point.".into());
     }
 
-    // Rule 2: Check for unused variable pattern
-    if content.contains("let _") {
+    if config.check_unused_var && content.contains("let _") {
         return Err("Contains unused variable pattern `let _`.".into());
     }
 
-    // Rule 3: Check for unused imports (heuristic)
-    if let Some(warning) = check_unused_imports(&content) {
-        println!("{}", warning);
+    if config.check_unused_import {
+        if let Some(warning) = check_unused_imports(&content) {
+            println!("{}", warning);
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 use std::env;
 use std::process::Command;
 use std::str;
-use rust_checker::{validate_rust_file, scanner::scan_rust_files, rules::RuleConfig};
+use rust_checker::{
+    validate_rust_file,
+    scanner::scan_rust_files,
+    rules::RuleConfig,
+    report::{FileValidationResult, ValidationSummary, print_json_report},
+};
 use chrono::Utc;
 use colored::*;
 
@@ -13,12 +18,14 @@ fn main() {
         eprintln!("{}", "\nOptional flags:".blue());
         eprintln!("  --skip-main             Skip `fn main` check");
         eprintln!("  --allow-unused-var      Allow `let _` pattern");
-        eprintln!("  --allow-unused-import   Allow unused `use` statements\n");
+        eprintln!("  --allow-unused-import   Allow unused `use` statements");
+        eprintln!("  --json                  Output report as JSON\n");
         std::process::exit(1);
     }
 
     let project_path = &args[1];
     let config = RuleConfig::from_args(&args);
+    let output_json = args.contains(&"--json".to_string());
 
     println!(
         "{}",
@@ -40,38 +47,59 @@ fn main() {
         parse_and_display_errors(stderr);
     }
 
-    // Step 2: Recursively validate each Rust file and track summary
+    // Step 2: Recursively validate each Rust file and collect results
     let rust_files = scan_rust_files(project_path);
     if rust_files.is_empty() {
-        println!("{}", "️ No .rs files found in the directory.".yellow());
+        println!("{}", " No .rs files found in the directory.".yellow());
         return;
     }
 
     let mut passed = 0;
     let mut failed = 0;
+    let mut results = Vec::new();
 
     for file_path in rust_files {
         match validate_rust_file(&file_path, &config) {
             Ok(_) => {
                 println!("{}", format!(" {} passed validation.", file_path).green());
                 passed += 1;
+                results.push(FileValidationResult {
+                    file: file_path,
+                    passed: true,
+                    error: None,
+                });
             }
             Err(e) => {
                 eprintln!("{}", format!(" {} failed validation: {}", file_path, e).red());
                 failed += 1;
+                results.push(FileValidationResult {
+                    file: file_path,
+                    passed: false,
+                    error: Some(e),
+                });
             }
         }
     }
 
-    let total = passed + failed;
-    println!(
-        "\n{}",
-        format!(
-            " Summary:  {} passed |  {} failed |  {} total files checked",
-            passed, failed, total
-        )
-        .bold()
-    );
+    let summary = ValidationSummary {
+        total_files: passed + failed,
+        passed,
+        failed,
+        results,
+    };
+
+    if output_json {
+        print_json_report(&summary);
+    } else {
+        println!(
+            "\n{}",
+            format!(
+                " Summary:  {} passed |  {} failed |  {} total files checked",
+                summary.passed, summary.failed, summary.total_files
+            )
+            .bold()
+        );
+    }
 }
 
 fn parse_and_display_errors(output: &str) {

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct FileValidationResult {
+    pub file: String,
+    pub passed: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidationSummary {
+    pub total_files: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub results: Vec<FileValidationResult>,
+}
+
+pub fn print_json_report(summary: &ValidationSummary) {
+    match serde_json::to_string_pretty(summary) {
+        Ok(json) => println!("{}", json),
+        Err(e) => eprintln!("Failed to serialize report: {}", e),
+    }
+}
+

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,0 +1,19 @@
+/// Holds configuration flags for validation rules
+#[derive(Default)]
+pub struct RuleConfig {
+    pub check_main: bool,
+    pub check_unused_var: bool,
+    pub check_unused_import: bool,
+}
+
+impl RuleConfig {
+    /// Construct RuleConfig from command-line args
+    pub fn from_args(args: &[String]) -> Self {
+        RuleConfig {
+            check_main: !args.contains(&"--skip-main".to_string()),
+            check_unused_var: !args.contains(&"--allow-unused-var".to_string()),
+            check_unused_import: !args.contains(&"--allow-unused-import".to_string()),
+        }
+    }
+}
+


### PR DESCRIPTION
- Adds `report.rs` module for JSON serialization using `serde`
- Supports `--json` CLI flag to export per-file results
- Summary includes file paths, validation status, and error messages
- Integrates with existing colorized CLI feedback

Co-authored-by: hansonp <hansonp303@gmail.com>
