### PR TITLE
Add optional cargo fmt and clippy checks via CLI flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use std::fs;
 
 pub mod unused_checker;
 pub mod rules;
+pub mod tooling;
+
 
 use unused_checker::check_unused_imports;
 use rules::RuleConfig;

--- a/src/tooling.rs
+++ b/src/tooling.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+pub fn run_fmt_check(path: &str) -> bool {
+    let status = Command::new("cargo")
+        .arg("fmt")
+        .arg("--check")
+        .current_dir(path)
+        .status()
+        .expect("Failed to run cargo fmt");
+
+    status.success()
+}
+
+pub fn run_clippy_check(path: &str) -> bool {
+    let status = Command::new("cargo")
+        .arg("clippy")
+        .arg("--quiet")
+        .arg("--")
+        .arg("-Dwarnings") // fail on warnings
+        .current_dir(path)
+        .status()
+        .expect("Failed to run cargo clippy");
+
+    status.success()
+}
+


### PR DESCRIPTION
This feature introduces developer tooling integration:

- `--check-fmt` runs `cargo fmt --check` to ensure code is formatted
- `--check-clippy` runs `cargo clippy --quiet -- -Dwarnings` to lint code
- Tooling logic is encapsulated in `src/tooling.rs`
- Results are displayed in color-coded CLI output

Co-authored-by: hansonp <hansonp303@gmail.com>
