### PR TITLE
Add Git pre-commit hook installer for automatic validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[[bin]]
+name = "install_git_hook"
+path = "scripts/install_git_hook.rs"
+

--- a/scripts/install_git_hook.rs
+++ b/scripts/install_git_hook.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+fn main() {
+    let hook_path = Path::new(".git/hooks/pre-commit");
+
+    let script = r#"#!/bin/sh
+echo "🔍 Running rust_checker before commit..."
+cargo run -- . || {
+    echo " rust_checker validation failed. Commit aborted."
+    exit 1
+}
+"#;
+
+    if let Some(parent) = hook_path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create hooks directory");
+    }
+
+    let mut file = fs::File::create(&hook_path).expect("Failed to create pre-commit hook");
+    file.write_all(script.as_bytes())
+        .expect("Failed to write pre-commit script");
+
+    let mut perms = fs::metadata(&hook_path).expect("Failed to read permissions").permissions();
+    perms.set_mode(0o755); // make it executable
+    fs::set_permissions(&hook_path, perms).expect("Failed to set executable permissions");
+
+    println!(" Git pre-commit hook installed successfully.");
+}
+


### PR DESCRIPTION
- Adds a Rust script (`scripts/install_git_hook.rs`) that installs `.git/hooks/pre-commit`
- The hook runs `cargo run -- .` before every commit
- Commits are blocked if validation fails
- Helps enforce code checks automatically for all contributors

To install the hook:
```bash
cargo run --bin install_git_hook
