### PR TITLE
Introduce Actix Web dashboard for validation results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2021"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+actix-web = "4"
+tokio = { version = "1", features = ["full"] }
 
 [[bin]]
 name = "install_git_hook"
 path = "scripts/install_git_hook.rs"
-
+name = "web"
+path = "src/bin/web.rs"

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -1,0 +1,33 @@
+use rust_checker::report::{ValidationSummary, FileValidationResult};
+use rust_checker::web::run_dashboard;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    // Example placeholder summary to serve
+    let summary = ValidationSummary {
+        total_files: 3,
+        passed: 2,
+        failed: 1,
+        results: vec![
+            FileValidationResult {
+                file: "src/main.rs".into(),
+                passed: true,
+                error: None,
+            },
+            FileValidationResult {
+                file: "src/lib.rs".into(),
+                passed: false,
+                error: Some("Missing `fn main`".into()),
+            },
+            FileValidationResult {
+                file: "src/web/mod.rs".into(),
+                passed: true,
+                error: None,
+            },
+        ],
+    };
+
+    println!(" Starting Rust Checker Web Dashboard at http://localhost:8080");
+    run_dashboard(summary).await
+}
+

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,0 +1,28 @@
+use actix_web::{get, web, App, HttpServer, Responder, HttpResponse};
+use crate::report::{ValidationSummary, FileValidationResult};
+use std::sync::Mutex;
+
+#[get("/")]
+async fn index() -> impl Responder {
+    HttpResponse::Ok().body(" Rust Checker Web Dashboard is running!")
+}
+
+#[get("/summary")]
+async fn summary(data: web::Data<Mutex<ValidationSummary>>) -> impl Responder {
+    let summary = data.lock().unwrap();
+    HttpResponse::Ok().json(&*summary)
+}
+
+pub async fn run_dashboard(summary: ValidationSummary) -> std::io::Result<()> {
+    let shared_data = web::Data::new(Mutex::new(summary));
+    HttpServer::new(move || {
+        App::new()
+            .app_data(shared_data.clone())
+            .service(index)
+            .service(summary)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}
+


### PR DESCRIPTION
- Adds `/` and `/summary` endpoints using Actix Web
- Uses a shared `ValidationSummary` model to expose validation results via HTTP
- Includes `src/bin/web.rs` for launching the dashboard
- Designed to support future HTML or frontend rendering

Run with:
```bash
cargo run --bin web
