### PR TITLE
Enable parallel file validation using Rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 actix-web = "4"
 tokio = { version = "1", features = ["full"] }
+rayon = "1.8"
 
 [[bin]]
 name = "install_git_hook"


### PR DESCRIPTION
- Adds parallel iteration for Rust file validation using the `rayon` crate
- Improves performance on large projects by validating files concurrently
- All results are collected and displayed in summary
- Preserves JSON and colored CLI support

Co-authored-by: hansonp <hansonp303@gmail.com>
