### PR TITLE
Add config file support via .rustchecker.toml

### DIFF
--- a/.rustchecker.toml
+++ b/.rustchecker.toml
@@ -1,0 +1,5 @@
+[rules]
+check_main = true
+check_unused_var = false
+check_unused_import = true
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ serde_json = "1.0"
 actix-web = "4"
 tokio = { version = "1", features = ["full"] }
 rayon = "1.8"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
 
 [[bin]]
 name = "install_git_hook"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,22 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Config {
+    pub rules: Option<RuleConfig>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct RuleConfig {
+    pub check_main: Option<bool>,
+    pub check_unused_var: Option<bool>,
+    pub check_unused_import: Option<bool>,
+}
+
+impl Config {
+    pub fn load(path: &str) -> Self {
+        let content = fs::read_to_string(path).unwrap_or_default();
+        toml::from_str(&content).unwrap_or_default()
+    }
+}
+

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,18 +1,53 @@
-/// Holds configuration flags for validation rules
-#[derive(Default)]
+use crate::config::RuleConfig as FileRuleConfig;
+
+#[derive(Debug, Clone)]
 pub struct RuleConfig {
     pub check_main: bool,
     pub check_unused_var: bool,
     pub check_unused_import: bool,
 }
 
+impl Default for RuleConfig {
+    fn default() -> Self {
+        Self {
+            check_main: true,
+            check_unused_var: true,
+            check_unused_import: true,
+        }
+    }
+}
+
 impl RuleConfig {
-    /// Construct RuleConfig from command-line args
     pub fn from_args(args: &[String]) -> Self {
-        RuleConfig {
+        Self {
             check_main: !args.contains(&"--skip-main".to_string()),
             check_unused_var: !args.contains(&"--allow-unused-var".to_string()),
             check_unused_import: !args.contains(&"--allow-unused-import".to_string()),
+        }
+    }
+
+    pub fn from_args_and_config(args: &[String], file: Option<FileRuleConfig>) -> Self {
+        let cli = Self::from_args(args);
+        if let Some(cfg) = file {
+            Self {
+                check_main: if args.contains(&"--skip-main".to_string()) {
+                    false
+                } else {
+                    cfg.check_main.unwrap_or(cli.check_main)
+                },
+                check_unused_var: if args.contains(&"--allow-unused-var".to_string()) {
+                    false
+                } else {
+                    cfg.check_unused_var.unwrap_or(cli.check_unused_var)
+                },
+                check_unused_import: if args.contains(&"--allow-unused-import".to_string()) {
+                    false
+                } else {
+                    cfg.check_unused_import.unwrap_or(cli.check_unused_import)
+                },
+            }
+        } else {
+            cli
         }
     }
 }


### PR DESCRIPTION
- Adds config support to load rule flags from `.rustchecker.toml`
- Merges CLI arguments with file-based rule definitions
- Supports:
  - `check_main`
  - `check_unused_var`
  - `check_unused_import`
- Example config:
```toml
[rules]
check_main = true
check_unused_var = false
check_unused_import = true
