### PR TITLE
Add HTML report export to target/report.html

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,10 @@ use rust_checker::{
     scanner::scan_rust_files,
     rules::RuleConfig,
     report::{FileValidationResult, ValidationSummary, print_json_report},
+    report::html::export_to_html,
     tooling::{run_fmt_check, run_clippy_check},
     config::Config,
-    fixer::auto_fix_unused_imports, //  Auto-fix support
+    fixer::auto_fix_unused_imports,
 };
 use chrono::Utc;
 use colored::*;
@@ -75,11 +76,10 @@ fn main() {
 
     let rust_files = scan_rust_files(project_path);
     if rust_files.is_empty() {
-        println!("{}", " ️ No .rs files found in the directory.".yellow());
+        println!("{}", "  No .rs files found in the directory.".yellow());
         return;
     }
 
-    //  Auto-fix before validation
     if auto_fix {
         for file_path in &rust_files {
             match auto_fix_unused_imports(file_path) {
@@ -137,11 +137,18 @@ fn main() {
         println!(
             "\n{}",
             format!(
-                " Summary:  {} passed |  {} failed |  {} total files checked",
+                "📝 Summary:  {} passed |  {} failed |  {} total files checked",
                 summary.passed, summary.failed, summary.total_files
             )
             .bold()
         );
+    }
+
+    //  HTML export
+    if let Err(e) = export_to_html(&summary, "target/report.html") {
+        eprintln!(" Failed to export HTML report: {}", e);
+    } else {
+        println!("{}", " HTML report saved to target/report.html".blue());
     }
 }
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,0 +1,47 @@
+use crate::report::{ValidationSummary, FileValidationResult};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+pub fn export_to_html(summary: &ValidationSummary, path: &str) -> Result<(), String> {
+    let output_path = Path::new(path);
+    fs::create_dir_all(output_path.parent().unwrap_or(Path::new("target")))
+        .map_err(|e| format!("Failed to create output directory: {}", e))?;
+
+    let mut file = File::create(output_path).map_err(|e| format!("Failed to create file: {}", e))?;
+
+    writeln!(file, "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Rust Checker Report</title>
+    <style>
+    body {{ font-family: Arial; background: #fdfdfd; color: #333; }}
+    h1 {{ color: #005f8a; }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th, td {{ padding: 8px; border: 1px solid #ccc; }}
+    .pass {{ background-color: #e0ffe0; }}
+    .fail {{ background-color: #ffe0e0; }}
+    </style></head><body>")?;
+
+    writeln!(file, "<h1>Rust Checker Validation Summary</h1>")?;
+    writeln!(
+        file,
+        "<p><strong>Files Checked:</strong> {} | <strong>Passed:</strong> {} | <strong>Failed:</strong> {}</p>",
+        summary.total_files, summary.passed, summary.failed
+    )?;
+
+    writeln!(file, "<table><tr><th>File</th><th>Status</th><th>Error</th></tr>")?;
+    for FileValidationResult { file, passed, error } in &summary.results {
+        let class = if *passed { "pass" } else { "fail" };
+        writeln!(
+            file,
+            "<tr class=\"{}\"><td>{}</td><td>{}</td><td>{}</td></tr>",
+            class,
+            file,
+            if *passed { " Passed" } else { " Failed" },
+            error.clone().unwrap_or_default()
+        )?;
+    }
+
+    writeln!(file, "</table></body></html>")?;
+
+    Ok(())
+}
+


### PR DESCRIPTION
- Exports validation results to a styled HTML report
- Output is saved to `target/report.html`
- Each file shows pass/fail status and any errors
- Supports CI/CD artifact viewing and sharing

Co-authored-by: hansonp <hansonp303@gmail.com>
